### PR TITLE
set the version of Java to Oracle JDK 8 in circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
+machine:
+  java:
+    version: oraclejdk8
 
 checkout:
     post:


### PR DESCRIPTION
@DefinitlyEvil said

> java 7 & below is not supported
> Only Java 8 and +

The default version on circle**ci** is `oraclejdk7`, so let's move to `oraclejdk8` !
